### PR TITLE
Make taser craftable with ingots from other mods

### DIFF
--- a/src/main/resources/data/ag4tr/recipes/taser.json
+++ b/src/main/resources/data/ag4tr/recipes/taser.json
@@ -7,16 +7,16 @@
     ],
     "key": {
         "#": {
-            "item": "c:tin_nuggets"
+            "tag": "c:tin_nuggets"
         },
         "N": {
-            "item": "c:copper_ingots"
+            "tag": "c:copper_ingots"
         },
         "K": {
             "item": "techreborn:electronic_circuit"
         },
         "i": {
-            "item": "c:refined_iron_ingots"
+            "tag": "c:refined_iron_ingots"
         },
         "B": {
             "item": "techreborn:red_cell_battery"

--- a/src/main/resources/data/ag4tr/recipes/taser.json
+++ b/src/main/resources/data/ag4tr/recipes/taser.json
@@ -7,16 +7,16 @@
     ],
     "key": {
         "#": {
-            "item": "techreborn:tin_nugget"
+            "item": "c:tin_nuggets"
         },
         "N": {
-            "item": "techreborn:copper_ingot"
+            "item": "c:copper_ingots"
         },
         "K": {
             "item": "techreborn:electronic_circuit"
         },
         "i": {
-            "item": "techreborn:refined_iron_ingot"
+            "item": "c:refined_iron_ingots"
         },
         "B": {
             "item": "techreborn:red_cell_battery"


### PR DESCRIPTION
Without this tweak it's impossible to craft a taser on my world. When smelted, all ore becomes Atromine ingots, and there is no way to convert it back.